### PR TITLE
FeatureRegProperty fix utf_16 encoding and length

### DIFF
--- a/usb_protocol/types/descriptors/microsoft.py
+++ b/usb_protocol/types/descriptors/microsoft.py
@@ -103,15 +103,15 @@ FeatureCompatibleID = DescriptorFormat(
 
 
 FeatureRegProperty = DescriptorFormat(
-    "wLength"             / construct.Rebuild(construct.Int16ul, 10 + this.wPropertyNameLength + this.wPropertyDataLength),
+    "wLength"             / construct.Rebuild(construct.Int16ul, 10 + 2 + 2*len_(this.PropertyName) + 2 + 2*len_(this.PropertyData)),
     "wDescriptorType"     / construct.Const(OSDescriptorTypes.FEATURE_REG_PROPERTY, construct.Int16ul),
     "wPropertyDataType"   / DescriptorField("Data type of the registry property"),
-    "wPropertyNameLength" / construct.Rebuild(construct.Int16ul, len_(this.PropertyName)),
-    "PropertyName"        / construct.CString("utf16"),
-    "wPropertyDataLength" / construct.Rebuild(construct.Int16ul, len_(this.PropertyData)),
+    "wPropertyNameLength" / construct.Rebuild(construct.Int16ul, 2 + 2*len_(this.PropertyName)),
+    "PropertyName"        / construct.CString("utf_16_le"),
+    "wPropertyDataLength" / construct.Rebuild(construct.Int16ul, 2 + 2*len_(this.PropertyData)),
     "PropertyData"        / construct.Union(
             this.wPropertyNameLength,
-            construct.CString("utf16"),
+            construct.CString("utf_16_le"),
             construct.Bytes(this.wPropertyNameLength)
         ),
 )


### PR DESCRIPTION
Some fixes on the FeatureRegProperty used by MS OS 2.0 Descriptors.

- Use "utf_16_le" to ensure that strings aren't prepneded with extra 0xFF 0xFE
- Count null termination and, and multiply by 2 to get expected byte count for utf16 lengths.

I was also seeing issues chaining Construct.Rebuild, but that might have just been a feature I need to update my local Construt to fix.